### PR TITLE
Add reference to oslex to the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,3 +52,10 @@ This package was created with Cookiecutter_ and the `audreyr/cookiecutter-pypack
 
 .. _Cookiecutter: https://github.com/audreyr/cookiecutter
 .. _`audreyr/cookiecutter-pypackage`: https://github.com/audreyr/cookiecutter-pypackage
+
+Automatic selection between mslex and shlex
+-------------------------------------------
+
+If you want to automatically use mslex on Windows, and shlex otherwise, check out the `oslex`_ package.
+
+.. _`oslex`: https://pypi.org/project/oslex/


### PR DESCRIPTION
This is a shameless self-plug.

I was inspired by `mslex` to create my own library called `oslex` which simply dispatches between `shlex` and `mslex` based on OS. I think it might be useful to make it easier for people to find it by linking to it from your README; however, I'm completely fine with it if you don't want to advertise my library.
